### PR TITLE
Fix license issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pyglotaran
 
 Home: https://github.com/glotaran/pyglotaran
 
-Package license: GPL-3.0-only
+Package license: LGPL-3.0-only
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyglotaran-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 02043f9a7cf3c4ff3c9a02bc4202b787f57d8a9d767e659eb33f397006bcf2ca
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - glotaran=glotaran.cli.main:glotaran


### PR DESCRIPTION
The license is still set to GPL3 after changing it to LGPL3 at the 0.3.0 release.
Guess I forgot the rerender.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
