### PR TITLE
Fix license issue for 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 02043f9a7cf3c4ff3c9a02bc4202b787f57d8a9d767e659eb33f397006bcf2ca
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - glotaran=glotaran.cli.main:glotaran
@@ -48,7 +48,7 @@ test:
 
 about:
   home: https://github.com/glotaran/pyglotaran
-  license: LGPL-3.0-only
+  license: LGPL-3.0
   license_family: LGPL
   license_file: LICENSE
   summary: The Glotaran fitting engine.


### PR DESCRIPTION
Bumped built number and change license to OSI identifier.
For some reason, 'LGPL-3.0-only' from [SPDX](https://spdx.org/licenses/) doesn't work properly so maybe the [OSI version](https://opensource.org/licenses/lgpl-3.0.html) will fix the issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
